### PR TITLE
feat: add `getDirStats` util

### DIFF
--- a/src/node/get-dir-stats.ts
+++ b/src/node/get-dir-stats.ts
@@ -1,0 +1,74 @@
+import { readdir, stat } from 'node:fs/promises'
+import { resolve, parse, basename } from 'node:path'
+import { formatBytes } from '../mix/format-bytes'
+import type { DirStats, DirStatsOptions } from '../types/node'
+
+/**
+ * Scans the specified directory and gets details for each subdirectory and file.
+ *
+ * By default, recursive mode is disabled so only one level is scanned.
+ */
+export async function getDirStats(dirPath: string, options?: DirStatsOptions) {
+  const dirFiles = await readdir(dirPath)
+  const dirBase = basename(dirPath)
+
+  let dirStats: DirStats[] = []
+  const subdirList: DirStats['subdirs'] = []
+  const fileList: DirStats['files'] = []
+
+  let dirSize = 0
+  let dirIndex = 0
+  let fileIndex = -1
+  let subdirIndex = -1
+
+  for (const file of dirFiles) {
+    const filePath = resolve(dirPath, file)
+    const fileStat = await stat(filePath)
+
+    if (fileStat.isDirectory()) {
+      subdirIndex++
+
+      subdirList.push({
+        index: subdirIndex,
+        path: filePath,
+        base: file
+      })
+
+      if (options?.recursive) {
+        dirBase === dirPath ? dirBase : basename(filePath)
+
+        const stats = await getDirStats(filePath)
+        const updateDirStats = { ...stats[0], ...{ index: dirIndex++ } }
+
+        dirStats = [...dirStats, updateDirStats]
+      }
+    } else {
+      const { base, name, ext } = parse(file)
+      const path = filePath
+      const size = formatBytes(fileStat.size)
+
+      fileIndex++
+      dirSize += fileStat.size
+
+      fileList.push({
+        index: fileIndex,
+        path,
+        base,
+        name,
+        ext,
+        size
+      })
+    }
+  }
+
+  dirStats.push({
+    index: dirIndex,
+    path: dirPath,
+    base: dirBase,
+    size: formatBytes(dirSize),
+    subdirs: subdirList,
+    files: fileList
+  })
+
+  return dirStats
+}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,1 +1,2 @@
 export * from './exists'
+export * from './get-dir-stats'

--- a/src/types/node/get-dir-stats.ts
+++ b/src/types/node/get-dir-stats.ts
@@ -1,0 +1,30 @@
+interface SubdirDetails {
+  index: number
+  path: string
+  base: string
+}
+
+interface FileDetails {
+  index: number
+  path: string
+  base: string
+  name: string
+  ext: string
+  size: string
+}
+
+export interface DirStats {
+  index: number
+  path: string
+  base: string
+  size: string
+  subdirs: SubdirDetails[]
+  files: FileDetails[]
+}
+
+export interface DirStatsOptions {
+  recursive?: boolean
+}
+
+// Auto-generated
+export * from '../../node/get-dir-stats'

--- a/src/types/node/index.ts
+++ b/src/types/node/index.ts
@@ -1,1 +1,2 @@
 export * from './exists'
+export * from './get-dir-stats'


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Request Description

Adds `getDirStats` util.

### Example

Dir structure:

```
./dist
│  ├── mix/
│  └── node/
├── utils.cjs
├── utils.d.ts
└── utils.mjs

```

Dir stats:

```ts
import { getDirStats } from '@hypernym/utils/node'

console.log(await getDirStats('./dist'))

/* Output:

[
  {
    index: 0,
    path: '.../dist',
    base: 'dist',
    size: 7454,
    subdirs: [
      {
        index: 0,
        path: '.../dist/mix',
        base: 'mix'
      },
      {
        index: 1,
        path: '.../dist/node',
        base: 'node'
      }
    ],
    files: [
      {
        index: 0,
        path: '.../dist/utils.cjs',
        base: 'utils.cjs',
        name: 'utils',
        ext: '.cjs',
        size: 2553
      },
      {
        index: 1,
        path: '.../dist/utils.d.ts',
        base: 'utils.d.ts',
        name: 'utils.d',
        ext: '.ts',
        size: 1706
      },
      {
        index: 2,
        path: '.../dist/utils.mjs',
        base: 'utils.mjs',
        name: 'utils',
        ext: '.mjs',
        size: 3195
      }
    ]
  }
]

*/
```
