### PR TITLE
fix: update `getDirStats` util

### DIFF
--- a/src/types/node/get-dir-stats.ts
+++ b/src/types/node/get-dir-stats.ts
@@ -10,14 +10,14 @@ interface FileDetails {
   base: string
   name: string
   ext: string
-  size: string
+  size: number
 }
 
 export interface DirStats {
   index: number
   path: string
   base: string
-  size: string
+  size: number
   subdirs: SubdirDetails[]
   files: FileDetails[]
 }


### PR DESCRIPTION

## Type of Change

- [x] Bug fix

## Request Description

Fixes `getDirStats` error and unformats bytes (for sizes) by default. 