### PR TITLE
feat: add `getDirFiles` util

### DIFF
--- a/src/node/get-dir-files.ts
+++ b/src/node/get-dir-files.ts
@@ -1,0 +1,29 @@
+import { readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { DirFilesOptions } from '../types/node'
+
+/**
+ * Scans the specified directory and returns a list of all files.
+ *
+ * By default, recursive mode is disabled so only one level is scanned.
+ */
+export async function getDirFiles(path: string, options?: DirFilesOptions) {
+  const dirPath = resolve(path)
+  const dirFiles = await readdir(dirPath, { withFileTypes: true })
+
+  let fileList: string[] = []
+
+  for (const file of dirFiles) {
+    const filePath = resolve(path, file.name)
+
+    if (file.isDirectory()) {
+      if (options?.recursive) {
+        fileList = [...fileList, ...(await getDirFiles(filePath))]
+      }
+    } else {
+      fileList.push(filePath)
+    }
+  }
+
+  return fileList
+}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,2 +1,3 @@
 export * from './exists'
 export * from './get-dir-stats'
+export * from './get-dir-files'

--- a/src/types/node/get-dir-files.ts
+++ b/src/types/node/get-dir-files.ts
@@ -1,0 +1,6 @@
+export interface DirFilesOptions {
+  recursive?: boolean
+}
+
+// Auto-generated
+export * from '../../node/get-dir-files'

--- a/src/types/node/index.ts
+++ b/src/types/node/index.ts
@@ -1,2 +1,3 @@
 export * from './exists'
 export * from './get-dir-stats'
+export * from './get-dir-files'


### PR DESCRIPTION

## Type of Change


- [x] New feature


## Request Description

Adds new `getDirFiles` utils.

### Example

```ts
import { getDirFiles } from '@hypernym/utils/node'

const files = await getDirFiles('./dist', { recursive: true })

console.log(files) // Array of strings

/* Outputs:

[
  '.../dist/index.cjs',
  '.../dist/index.d.ts',
  '.../dist/index.mjs',
  '.../dist/node/index.cjs',
  '.../dist/node/index.d.ts',
  '.../dist/node/index.mjs'
]

*/
```
