### PR TITLE
feat: add new fs copy util

### DIFF
--- a/src/fs/copy.ts
+++ b/src/fs/copy.ts
@@ -1,0 +1,49 @@
+import { cp } from 'node:fs/promises'
+import { isString, isURL } from '@'
+
+export interface CopyOptions {
+  /**
+   * Copies files or directories recursively.
+   *
+   * @default true
+   */
+  recursive?: boolean
+  /**
+   * Filters copied `files` or `directories`.
+   *
+   * Returns `true` to copy the item, `false` to ignore it.
+   *
+   * @default undefined
+   */
+  filter?(source: string, destination: string): boolean | Promise<boolean>
+}
+
+/**
+ * Copies `files` or `directories` recursively.
+ *
+ * Accepts a single source or a range of sources.
+ *
+ * @example
+ *
+ * ```ts
+ * import { copy } from '@hypernym/utils/fs'
+ *
+ * await copy('src/subdir/file.ts', './dist/subdir')
+ * ```
+ */
+export async function copy(
+  source: string | URL | (string | URL)[],
+  destination: string | URL,
+  options: CopyOptions,
+): Promise<void> {
+  const { recursive = true, filter } = options
+
+  const sources = isString(source) || isURL(source) ? [source] : source
+
+  for (const src of sources) {
+    await cp(src, destination, {
+      recursive,
+      filter,
+    })
+  }
+}

--- a/src/fs/exists.ts
+++ b/src/fs/exists.ts
@@ -8,7 +8,7 @@ import { access, constants } from 'node:fs/promises'
  * ```ts
  * import { exists } from '@hypernym/utils/fs'
  *
- * exists('dir/file.ts') // => true
+ * await exists('dir/file.ts') // => true
  * ```
  */
 export async function exists(path: string): Promise<boolean> {

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -1,2 +1,3 @@
 export * from './exists'
 export * from './write-file'
+export * from './copy'

--- a/src/fs/write-file.ts
+++ b/src/fs/write-file.ts
@@ -9,7 +9,7 @@ import { mkdir, writeFile as write } from 'node:fs/promises'
  * ```ts
  * import { writeFile } from '@hypernym/utils/fs'
  *
- * writeFile('dir/subdir/file.ts', `console.log('Hello World!')`)
+ * await writeFile('dir/subdir/file.ts', `console.log('Hello World!')`)
  * ```
  */
 export async function writeFile(


### PR DESCRIPTION

## Type of Change

- [x] New feature

## Request Description

Adds new fs `copy` util.

### copy

Copies `files` or `directories` recursively.

Accepts a single source or a range of sources.

```ts
import { copy } from '@hypernym/utils/fs'

await copy('src/subdir/file.ts', './dist/subdir')
```