### PR TITLE
feat: add new fs read util

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Also, it is possible to download files manually and serve them accordingly.
 
 ### isBrowser
 
-Checks if the code is running in the browser.
+Checks if the code is running in the `browser`.
 
 ```ts
 import { isBrowser } from '@hypernym/utils'
@@ -125,6 +125,16 @@ Checks if the file or directory exists.
 import { exists } from '@hypernym/utils/fs'
 
 await exists('dir/file.ts') // => true
+```
+
+### read
+
+Reads the entire contents of a file.
+
+```ts
+import { read } from '@hypernym/utils/fs'
+
+await read('dir/subdir/file.ts')
 ```
 
 ### write

--- a/src/fs/read.ts
+++ b/src/fs/read.ts
@@ -1,0 +1,50 @@
+import { readFile } from 'node:fs/promises'
+
+export type ReadPath = string | URL
+export type ReadEncodingType = BufferEncoding | null | undefined
+export type ReadType<T> = T extends BufferEncoding | undefined
+  ? string
+  : T extends null
+    ? Buffer
+    : never
+
+export interface ReadOptions<T extends ReadEncodingType> {
+  /**
+   * If no encoding is specified, the data is returned as a `Buffer` object. Otherwise, the data will be a string.
+   *
+   * @default 'utf-8'
+   */
+  encoding?: T
+  /**
+   * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
+   *
+   * @default undefined
+   */
+  signal?: AbortSignal
+  /**
+   * If a flag is not provided, it defaults to `'r'`.
+   *
+   * @default 'r'
+   */
+  flag?: number | string
+}
+
+/**
+ * Reads the entire contents of a file.
+ *
+ * @example
+ *
+ * ```ts
+ * import { read } from '@hypernym/utils/fs'
+ *
+ * await read('dir/subdir/file.ts')
+ * ```
+ */
+export async function read<T extends ReadEncodingType = BufferEncoding>(
+  path: ReadPath,
+  options: ReadOptions<T> = {},
+): Promise<ReadType<T>> {
+  const { encoding = 'utf-8' } = options
+
+  return (await readFile(path, { encoding, ...options })) as ReadType<T>
+}


### PR DESCRIPTION

## Type of Change

- [x] New feature

## Request Description

Adds a new fs `read` util.

### read

Reads the entire contents of a file.

```ts
import { read } from '@hypernym/utils/fs'

await read('dir/subdir/file.ts')
```